### PR TITLE
Updated go.mod to use cblib w/ URL, Windows  pathfixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.2
 
-require github.com/clearblade/cblib v0.0.0-20251021125134-814faa8679f5
+require github.com/clearblade/cblib v0.0.0-20251027153549-600e326680df
 
 require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/clearblade/Go-SDK v0.0.0-20250829145014-ec1c43d72f29 h1:Wpq7EHOdZTcO2
 github.com/clearblade/Go-SDK v0.0.0-20250829145014-ec1c43d72f29/go.mod h1:3p+ysXnI08VdBAVYKe9dndqsRVSXvLgxQqZxLtp/mCo=
 github.com/clearblade/cbjson v0.0.0-20160215162041-f1a77f1fc21c h1:KnJkP9fLFNyoV+pU3mXiRW5oLJdgDzVM/hWQhc0Scas=
 github.com/clearblade/cbjson v0.0.0-20160215162041-f1a77f1fc21c/go.mod h1:Pbu2bhtMVaWboL3mRaFQmGs8USG8uG4EAW2LB3SfCME=
-github.com/clearblade/cblib v0.0.0-20251021125134-814faa8679f5 h1:UdmOniBTMPs5yVNubn4xkSQAw9X/DiKXnaa9PR5rZ50=
-github.com/clearblade/cblib v0.0.0-20251021125134-814faa8679f5/go.mod h1:XEwBEMW4tWo94P7O82ssyc/EMgkLHMzR2CNT2Ynw+gw=
+github.com/clearblade/cblib v0.0.0-20251027153549-600e326680df h1:dL4x4a5iThFwGsbW+/6cT+qyugrOJNtuarsoAfV/ViA=
+github.com/clearblade/cblib v0.0.0-20251027153549-600e326680df/go.mod h1:XEwBEMW4tWo94P7O82ssyc/EMgkLHMzR2CNT2Ynw+gw=
 github.com/clearblade/go-utils v1.1.5-0.20240513160427-a20563b372a5 h1:bZ0WWsMfcukPazNfOG8rR/BXJieIDaF29YcJP0M1cu4=
 github.com/clearblade/go-utils v1.1.5-0.20240513160427-a20563b372a5/go.mod h1:oCpgejfd+56P7nlPGDQ3mpYnQWHjoBjStBXAokqWKV4=
 github.com/clearblade/mqtt_parsing v0.0.0-20160301165118-6ae49eac0961 h1:/T6Cq3XSwmuFoN6GDoPWgGpNW5X0Idx49DbfQazRUOQ=


### PR DESCRIPTION
Using the latest cblib that fixes Windows paths for creating .zip for pushes. Also added checks and corrects URL (appends missing 'https://' prefix & removes trailing slashes). Tested successfully on Ubuntu and Windows.